### PR TITLE
Updating to use the useNewUrlParser to end the deprecation warning

### DIFF
--- a/db.js
+++ b/db.js
@@ -8,7 +8,7 @@ module.exports = connectToDatabase = () => {
   }
 
   console.log('=> using new database connection');
-  return mongoose.connect(process.env.DB)
+  return mongoose.connect(process.env.DB, { useNewUrlParser: true })
     .then(db => { 
       isConnected = db.connections[0].readyState;
     });


### PR DESCRIPTION
DeprecationWarning: current URL string parser is deprecated, and will be removed in a future version.